### PR TITLE
fix: modifica la generación de códigos de trabajos de grado

### DIFF
--- a/app/Http/Controllers/TrabajoGradoController.php
+++ b/app/Http/Controllers/TrabajoGradoController.php
@@ -82,7 +82,6 @@ class TrabajoGradoController extends Controller
 
         $documento = $request->file("documento");
         $payload["filename"] = $documento->store("trabajos de grado");
-        $payload["codigo"] = Carbon::today()->year . '/' . (TrabajoGrado::count() + 1);
 
         $tutor_id = $payload["tutor"]["id"] ?? Tutor::create($payload["tutor"])->id;
         $trabajo = TrabajoGrado::create($payload + ["tutor_id" => $tutor_id]);

--- a/app/Models/TrabajoGrado.php
+++ b/app/Models/TrabajoGrado.php
@@ -8,21 +8,30 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 
 class TrabajoGrado extends Model
 {
     use HasFactory;
 
-    public $table = "trabajos_grado";
+    public $table = 'trabajos_grado';
 
     protected $fillable = [
-        "codigo",
-        "tema",
-        "resumen",
-        "filename",
-        "fecha_defensa",
-        "tutor_id"
+        'codigo',
+        'tema',
+        'resumen',
+        'filename',
+        'fecha_defensa',
+        'tutor_id'
     ];
+    protected static function booted(): void
+    {
+        static::creating(function (TrabajoGrado $trabajoGrado) {            
+            $year = Date::now()->year;
+            $counter = parent::where('codigo', 'like', $year.'/%')->count() + 1;
+            $trabajoGrado->attributes['codigo'] = "$year/$counter";
+        });
+    }
 
     #region Relationships
     public function tutor(): BelongsTo{
@@ -30,11 +39,11 @@ class TrabajoGrado extends Model
     }
 
     public function estudiantes(): BelongsToMany{
-        return $this->belongsToMany(Estudiante::class, "carrera_estudiante_trabajo_grado")->withPivot("carrera_id");
+        return $this->belongsToMany(Estudiante::class, 'carrera_estudiante_trabajo_grado')->withPivot('carrera_id');
     }
     
     public function carreras(): BelongsToMany{
-        return $this->belongsToMany(Carrera::class, "carrera_estudiante_trabajo_grado")->withPivot("estudiante_id");
+        return $this->belongsToMany(Carrera::class, 'carrera_estudiante_trabajo_grado')->withPivot('estudiante_id');
     }
     #endregion
 }

--- a/database/factories/TrabajoGradoFactory.php
+++ b/database/factories/TrabajoGradoFactory.php
@@ -15,6 +15,8 @@ use Illuminate\Support\Arr;
  */
 class TrabajoGradoFactory extends Factory
 {
+    protected $unsets = [];
+
     /**
      * Define the model's default state.
      *
@@ -22,12 +24,26 @@ class TrabajoGradoFactory extends Factory
      */
     public function definition()
     {
-        return [
+        return $this->unset([
             // "codigo" => $this->faker->numerify("####/##"),
             "tema" => $this->faker->realText(200),
             "resumen" => $this->faker->realTextBetween(400, 800),
-            "fecha_defensa" => $this->faker->date()
-        ];
+            "fecha_defensa" => $this->faker->date(),
+            "tutor_id" => Tutor::factory(),
+            "filename" => $this->faker->filePath()
+        ], $this->unsets);
+    }
+
+    /**
+     * Uset multiple keys from array
+     * 
+     * @return array
+     */
+    protected function unset($array, $keys){
+        foreach ($keys as $key ) {
+            unset($array[$key]);
+        }
+        return $array;
     }
 
     public function prepareForRequest($persistTutor=false, $persistEstudiantes=0, $totalEstudiantes=2)
@@ -42,11 +58,18 @@ class TrabajoGradoFactory extends Factory
         foreach($estudiantes as &$estudiante){
             $estudiante["carrera_id"] = Carrera::factory()->for(Facultad::factory())->create()->id;
         }
+        $this->unsets += ["filename", "tutor_id"];
 
         return $this->state([
             "documento" => UploadedFile::fake()->create('avatar.pdf', "1500", "application/pdf"),
             "tutor" => is_array($tutor) ? $tutor : $tutor->toArray(),
             "estudiantes" => $estudiantes
         ]);
+    }
+
+    public function newInstance(array $arguments = []){
+        $instance = parent::newInstance($arguments);
+        $instance->unsets = $this->unsets;
+        return $instance;
     }
 }

--- a/tests/Feature/TrabajoGrado/TrabajoGradoTest.php
+++ b/tests/Feature/TrabajoGrado/TrabajoGradoTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\TrabajoGrado;
+
+it("genera un codigo valido cuando la base de datos esta vacia", function(){
+    $this->travelTo("2020/05/11");
+    $trabajoGrado = TrabajoGrado::factory()->create();
+    expect($trabajoGrado->codigo)->toBe("2020/1");
+});
+
+it("genera un codigo valido cuando existen trabajos registrados", function(){
+    $this->travelTo("2020/05/11");
+    TrabajoGrado::factory(4)->create();
+    $trabajoGrado = TrabajoGrado::factory()->create();    
+    expect($trabajoGrado->codigo)->toBe("2020/5");
+});
+
+it("genera un codigo valido cuando existen trabajos registrados en distintos años", function(){
+    $this->travelTo("2020/05/11");
+    TrabajoGrado::factory(4)->create();
+    $this->travelTo("2021/05/11");
+    TrabajoGrado::factory(6)->create();
+    $trabajoGrado = TrabajoGrado::factory()->create();
+    expect($trabajoGrado->codigo)->toBe("2021/7");
+});


### PR DESCRIPTION
Se agregó una condición a la consulta de la base de datos para contar los trabajos registrados por año. Esto soluciona el error reportado en #8 
Adicionalmente se refactorizó el código para que se genere automáticamente al guardar el registro a la base de datos.